### PR TITLE
Revert "Update to use python3-nmap"

### DIFF
--- a/masstomap.py
+++ b/masstomap.py
@@ -11,7 +11,7 @@
 import re
 import os
 import sys
-import nmap3
+import nmap
 import argparse
 import xml.dom.minidom
 import threading

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 argparse
-python3-nmap @ git+https://github.com/nmmapper/python3-nmap
+-e git://github.com/dogasantos/python-nmap.git#egg=python-nmap


### PR DESCRIPTION
Reverts dogasantos/masstomap#3
nmap3 breaks the tool as it does not have a direct call to save results to a file.
The results here are in different format (json) and it will require detailed review on how to take advantage of this library and make it work. In the mean time, i'll rever to the original (working ) state.